### PR TITLE
📦 Rename artifact packages name in Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,10 +67,10 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         continue-on-error: false
 
-      - name: Generating `macOS Big Sur` Cursor Theme
+      - name: Generating `macOSBigSur` Cursor Theme
         run: python build.py
 
-      - name: Uploading `macOS Big Sur` Build Log artifact
+      - name: Uploading `macOSBigSur` Build Log artifact
         uses: actions/upload-artifact@v2
         with:
           name: logs
@@ -82,8 +82,8 @@ jobs:
           name: bitmaps
           path: bitmaps/*
 
-      - name: Uploading `macOS Big Sur` Theme artifact
+      - name: Uploading `macOSBigSur` Theme artifact
         uses: actions/upload-artifact@v2
         with:
-          name: macOS Big Sur
+          name: macOSBigSur
           path: themes


### PR DESCRIPTION
## What kind of change does this PR introduce?
Build **artifacts** are taken time to uncompress in **terminal** with` `(**white spaces). So I removed it 😊.

## What is the current behavior?
Artifact name with **whitespaces**(`macOS Big Sur`)

## What is the new behavior?
Rename to `macOSBigSur`

## What steps did you take to test this? This is required before I can merge, make sure to test the flow you've updated.

1. Rename **artifacts** name.

## Checklist

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
- [ ] Added myself to contributors table
