### PR TITLE
🛠️ Rearrance "make" commands for caching remove

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,4 @@
-theme := macOSBigSur
-src := ./themes/$(theme)
-
-local := ~/.icons
-local_dest := $(local)/$(theme)
-
-root := /usr/share/icons
-root_dest := $(root)/$(theme)
-
 all: clean render build
-
-unix: clean render bitmaps
-	@cd builder && make build_unix
-
-windows: clean render bitmaps
-	@cd builder && make build_windows
-
 .PHONY: all
 
 clean:
@@ -24,11 +8,29 @@ render: bitmapper svg
 	@cd bitmapper && $(MAKE)
 
 build: bitmaps
-	@cd builder && $(MAKE)
+	@cd builder && make build && make clean
+
+
+unix: clean render bitmaps
+	@cd builder && make build_unix && make clean
+
+windows: clean render bitmaps
+	@cd builder && make build_windows && make clean
+
+
+
+# Installation
+theme := macOSBigSur
+src := ./themes/$(theme)
+
+local := ~/.icons
+local_dest := $(local)/$(theme)
+
+root := /usr/share/icons
+root_dest := $(root)/$(theme)
 
 .ONESHELL:
 SHELL:=/bin/bash
-
 
 install: $(src)
 	@if [[ $EUID -ne 0 ]]; then

--- a/builder/Makefile
+++ b/builder/Makefile
@@ -1,6 +1,4 @@
-
 all: setup build
-
 .PHONY: all
 
 .ONESHELL:
@@ -23,11 +21,11 @@ clean:
 setup: clean setup.py
 	@python3 setup.py install --user --record files.txt
 
-build: setup build.py clean
+build: setup build.py
 	@python3 build.py --xsizes $(X_SIZES) --win-size $(WIN_SIZE) --win-canvas-size $(WIN_CANVAS_SIZE)
 
-build_unix: setup build.py clean
+build_unix: setup build.py
 	@python3 build.py unix --xsizes $(X_SIZES)
 
-build_windows: setup build.py clean
+build_windows: setup build.py
 	@python3 build.py windows --win-size $(WIN_SIZE) --win-canvas-size $(WIN_CANVAS_SIZE)


### PR DESCRIPTION
## What kind of change does this PR introduce?
Remove builder `cache` from `builder/*`

## What is the current behavior?

`make clean` command unable to remove cache of builder inside `builder/Makefile`

## What is the new behavior?

`Makefile` at the project root build target changed

## Checklist

- [ ] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
<!-- Thank you for contributing! -->
