### PR TITLE
v1.2.3: macOSMonterey cursor (sharp tail cursors)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,10 @@ jobs:
         with:
           python-version: "3.8"
 
+      - name: Generating `macOSMonterey` symlinks
+        run: cd svg && python link.py && cd ..
+        continue-on-error: false
+
       - name: Generating `macOSBigSur` Cursor Theme
         run: make bigsur
         continue-on-error: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,41 +57,67 @@ jobs:
         run: cd svg && python link.py && cd ..
         continue-on-error: false
 
-      - name: Generating `macOSBigSur` Cursor Theme
-        run: make bigsur
+      - name: Generating `macOS` Cursor Theme
+        run: make
         continue-on-error: false
 
-      - name: Compressing UNIX theme
+      - name: Compressing `macOS` UNIX themes
         run: |
           tar -cvzf macOSBigSur.tar.gz themes/macOSBigSur
           tar -cvzf macOSBigSur-White.tar.gz themes/macOSBigSur-White
+          tar -cvzf macOSMonterey.tar.gz themes/macOSMonterey
+          tar -cvzf macOSMonterey-White.tar.gz themes/macOSMonterey-White
 
-      - name: Uploading `bitmaps` artifact
+      - name: Uploading `macOSBigSur` bitmaps
         uses: actions/upload-artifact@v2
         with:
           name: bitmaps
           path: bitmaps/*
 
-      - name: Uploading `macOSBigSur` UNIX Theme artifact
+      - name: Uploading `macOSBigSur` UNIX Theme
         uses: actions/upload-artifact@v2
         with:
           name: macOSBigSur
           path: macOSBigSur.tar.gz
 
-      - name: Uploading `macOSBigSur-White` UNIX Theme artifact
+      - name: Uploading `macOSMonterey` UNIX Theme
+        uses: actions/upload-artifact@v2
+        with:
+          name: macOSMonterey
+          path: macOSMonterey.tar.gz
+
+      - name: Uploading `macOSBigSur-White` UNIX Theme
         uses: actions/upload-artifact@v2
         with:
           name: macOSBigSur-White
           path: macOSBigSur-White.tar.gz
 
-      - name: Uploading `macOSBigSur` Windows Theme artifact
+      - name: Uploading `macOSMonterey-White` UNIX Theme
+        uses: actions/upload-artifact@v2
+        with:
+          name: macOSMonterey-White
+          path: macOSMonterey-White.tar.gz
+
+      - name: Uploading `macOSBigSur` Windows Theme
         uses: actions/upload-artifact@v2
         with:
           name: macOSBigSur-Windows
           path: themes/macOSBigSur-Windows/*
 
-      - name: Uploading `macOSBigSur-White` Windows Theme artifact
+      - name: Uploading `macOSMonterey` Windows Theme
+        uses: actions/upload-artifact@v2
+        with:
+          name: macOSMonterey-Windows
+          path: themes/macOSMonterey-Windows/*
+
+      - name: Uploading `macOSBigSur-White` Windows Theme
         uses: actions/upload-artifact@v2
         with:
           name: macOSBigSur-White-Windows
           path: themes/macOSBigSur-White-Windows/*
+
+      - name: Uploading `macOSMonterey-White` Windows Theme
+        uses: actions/upload-artifact@v2
+        with:
+          name: macOSMonterey-White-Windows
+          path: themes/macOSMonterey-White-Windows/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- macOSMonterey cursors added 🎊 fixed #66
 - Generate master `bitmaps.zip` inside `bin` directory
 - `Makefile` binaries targets with variable
 - pling docs: size and support info updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [v1.2.3] - 23 Nov 2021
+
 ### Added
 
 - macOSMonterey cursors added 🎊 fixed #66

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - pling docs: size and support info updated
 - `bigsur` cursor bitmapper as node package
 - New commands added inside `Makefile` for `bitmapper`
+- symlink script for `macOSMonterey` svg files
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ clean:
 	@rm -rf bitmaps themes
 
 render: bitmapper svg
-	@cd bitmapper && make install render_bigsur
+	@cd bitmapper && make install render_bigsur render_monterey
 
 build: bitmaps
 	@cd builder && make setup build
@@ -29,11 +29,19 @@ render_bigsur: bitmapper svg
 build_bigsur: bitmaps
 	@cd builder && make setup build_bigsur
 
+# macOS Monterey
+monterey: clean render_monterey build_monterey
+
+render_monterey: bitmapper svg
+	@cd bitmapper && make install render_monterey
+
+build_monterey: bitmaps
+	@cd builder && make setup build_monterey
 
 # Installation
 .ONESHELL:
 SHELL:=/bin/bash
-THEME_PREFIX = macOSBigSur
+THEME_PREFIX = macOS
 
 src := ./themes/
 
@@ -48,24 +56,32 @@ install: $(src)
 	@if [[ $EUID -ne 0 ]]; then
 		@echo "> Installing '$(THEME_PREFIX)' cursors inside $(local)/..."
 		@mkdir -p $(local)
-		@cp -r ./themes/$(THEME_PREFIX) $(local_dest)
-		@cp -r ./themes/$(THEME_PREFIX)-White $(local_dest) && echo "> Installed!"
+		@cp -r ./themes/$(THEME_PREFIX)BigSur $(local_dest)
+		@cp -r ./themes/$(THEME_PREFIX)BigSur -White $(local_dest) && echo "> Installed!"
+		@cp -r ./themes/$(THEME_PREFIX)Monterey $(local_dest)
+		@cp -r ./themes/$(THEME_PREFIX)Monterey -White $(local_dest) && echo "> Installed!"
 	@else
 		@echo "> Installing '$(THEME_PREFIX)' cursors inside $(root)/..."
 		@mkdir -p $(root)
-		@sudo cp -r ./themes/$(THEME_PREFIX) $(root_dest)
-		@sudo cp -r ./themes/$(THEME_PREFIX)-White $(root_dest) && echo "> Installed!"
+		@sudo cp -r ./themes/$(THEME_PREFIX)BigSur $(root_dest)
+		@sudo cp -r ./themes/$(THEME_PREFIX)BigSur-White $(root_dest) && echo "> Installed!"
+		@sudo cp -r ./themes/$(THEME_PREFIX)Monterey $(root_dest)
+		@sudo cp -r ./themes/$(THEME_PREFIX)Monterey-White $(root_dest) && echo "> Installed!"
 	@fi
 
 uninstall:
 	@if [[ $EUID -ne 0 ]]; then
 		@echo "> Removing '$(THEME_PREFIX)' from '$(local)'..."
-		@rm -rf $(local)/$(THEME_PREFIX)
-		@rm -rf $(local)/$(THEME_PREFIX)-White
+		@rm -rf $(local)/$(THEME_PREFIX)BigSur
+		@rm -rf $(local)/$(THEME_PREFIX)BigSur-White
+		@rm -rf $(local)/$(THEME_PREFIX)Monterey
+		@rm -rf $(local)/$(THEME_PREFIX)Monterey-White
 	@else
 		@echo "> Removing '$(THEME_PREFIX)' from '$(root)'..."
-		@rm -rf $(root)/$(THEME_PREFIX)
-		@rm -rf $(root)/$(THEME_PREFIX)-White
+		@rm -rf $(root)/$(THEME_PREFIX)BigSur
+		@rm -rf $(root)/$(THEME_PREFIX)BigSur-White
+		@rm -rf $(root)/$(THEME_PREFIX)Monterey
+		@rm -rf $(root)/$(THEME_PREFIX)Monterey-White
 	@fi
 
 reinstall: uninstall install
@@ -76,16 +92,24 @@ BIN_DIR = ../bin
 THEMES = White
 prepare: bitmaps themes
 	@rm -rf bin
-	@mkdir -p bin/$(THEME_PREFIX)
-	@$(foreach theme,$(THEMES), mkdir -p bin/$(THEME_PREFIX)-$(theme);)
+	@mkdir -p bin/$(THEME_PREFIX)BigSur
+	@$(foreach theme,$(THEMES), mkdir -p bin/$(THEME_PREFIX)BigSur-$(theme);)
+	@mkdir -p bin/$(THEME_PREFIX)Monterey
+	@$(foreach theme,$(THEMES), mkdir -p bin/$(THEME_PREFIX)Monterey-$(theme);)
 	@cd bitmaps
-	@zip -r $(BIN_DIR)/$(THEME_PREFIX)/bitmaps.zip $(THEME_PREFIX)
-	@$(foreach theme,$(THEMES), zip -r $(BIN_DIR)/$(THEME_PREFIX)-$(theme)/bitmaps.zip $(THEME_PREFIX)-$(theme);)
+	@zip -r $(BIN_DIR)/$(THEME_PREFIX)BigSur/bitmaps.zip $(THEME_PREFIX)BigSur
+	@$(foreach theme,$(THEMES), zip -r $(BIN_DIR)/$(THEME_PREFIX)BigSur-$(theme)/bitmaps.zip $(THEME_PREFIX)BigSur-$(theme);)
+	@zip -r $(BIN_DIR)/$(THEME_PREFIX)Monterey/bitmaps.zip $(THEME_PREFIX)Monterey
+	@$(foreach theme,$(THEMES), zip -r $(BIN_DIR)/$(THEME_PREFIX)Monterey-$(theme)/bitmaps.zip $(THEME_PREFIX)Monterey-$(theme);)
 	@zip -r $(BIN_DIR)/bitmaps.zip *
 	@cd ..
 	@cd themes
-	@tar -czvf $(BIN_DIR)/$(THEME_PREFIX)/$(THEME_PREFIX).tar.gz $(THEME_PREFIX)
-	@zip -r $(BIN_DIR)/$(THEME_PREFIX)/$(THEME_PREFIX)-Windows.zip $(THEME_PREFIX)-Windows
-	@$(foreach theme,$(THEMES), tar -czvf $(BIN_DIR)/$(THEME_PREFIX)-$(theme)/$(THEME_PREFIX)-$(theme).tar.gz $(THEME_PREFIX)-$(theme);)
-	@$(foreach theme,$(THEMES), zip -r $(BIN_DIR)/$(THEME_PREFIX)-$(theme)/$(THEME_PREFIX)-$(theme)-Windows.zip $(THEME_PREFIX)-$(theme)-Windows;)
+	@tar -czvf $(BIN_DIR)/$(THEME_PREFIX)BigSur/$(THEME_PREFIX)BigSur.tar.gz $(THEME_PREFIX)BigSur
+	@zip -r $(BIN_DIR)/$(THEME_PREFIX)BigSur/$(THEME_PREFIX)BigSur-Windows.zip $(THEME_PREFIX)BigSur-Windows
+	@tar -czvf $(BIN_DIR)/$(THEME_PREFIX)Monterey/$(THEME_PREFIX)Monterey.tar.gz $(THEME_PREFIX)Monterey
+	@zip -r $(BIN_DIR)/$(THEME_PREFIX)Monterey/$(THEME_PREFIX)Monterey-Windows.zip $(THEME_PREFIX)Monterey-Windows
+	@$(foreach theme,$(THEMES), tar -czvf $(BIN_DIR)/$(THEME_PREFIX)BigSur-$(theme)/$(THEME_PREFIX)BigSur-$(theme).tar.gz $(THEME_PREFIX)BigSur-$(theme);)
+	@$(foreach theme,$(THEMES), zip -r $(BIN_DIR)/$(THEME_PREFIX)BigSur-$(theme)/$(THEME_PREFIX)BigSur-$(theme)-Windows.zip $(THEME_PREFIX)BigSur-$(theme)-Windows;)
+	@$(foreach theme,$(THEMES), tar -czvf $(BIN_DIR)/$(THEME_PREFIX)Monterey-$(theme)/$(THEME_PREFIX)Monterey-$(theme).tar.gz $(THEME_PREFIX)Monterey-$(theme);)
+	@$(foreach theme,$(THEMES), zip -r $(BIN_DIR)/$(THEME_PREFIX)Monterey-$(theme)/$(THEME_PREFIX)Monterey-$(theme)-Windows.zip $(THEME_PREFIX)Monterey-$(theme)-Windows;)
 	@cd ..

--- a/README.md
+++ b/README.md
@@ -36,10 +36,57 @@ Enjoy macOS cursors for `Windows` and `Linux` with _HiDPI Support_ .
 
 - macOSBigSur: [https://www.pling.com/p/1408466](https://www.pling.com/p/1408466)
 - macOSBigSur-White: [https://www.pling.com/p/1616779](https://www.pling.com/p/1616779)
+- macOSMonterey: [https://www.pling.com/p/1648124](https://www.pling.com/p/1648124)
+- macOSMonterey-White: [https://www.pling.com/p/1648129](https://www.pling.com/p/1648129)
+
+#### Preview:
+
+> Check Figma file [here](https://www.figma.com/file/OZw8Ylb9xPFw9h1uZYSMFa/Mac-Cursor?node-id=0%3A1)
+
+<p align="center">
+  <img title="macOSMonterey" src="https://imgur.com/bmS0fRT.png">
+  </br>
+  <sub>macOSMonterey Cursors</sub>
+</p>
+
+<p align="center">
+  <img title="macOSMonterey White" src="https://imgur.com/s0nqcje.png">
+  </br>
+  <sub>macOSMonterey White Cursors</sub>
+</p>
+
+<p align="center">
+  <img title="macOSBigSur" src="https://imgur.com/Q022eSp.png">
+  </br>
+  <sub>macOSBigSur Cursors</sub>
+</p>
+
+<p align="center">
+  <img title="macOSBigSur White" src="https://imgur.com/SFVR945.png">
+  </br>
+  <sub>macOSBigSur White Cursors</sub>
+</p>
 
 ### Manual Install
 
+> Note: replace name according package name.
+
 #### Linux/X11
+
+##### macOSMonterey
+
+```bash
+# extract `macOSMonterey.tar.gz`
+tar -xvf macOSMonterey.tar.gz
+
+# For local users
+mv macOSMonterey ~/.icons/
+
+# For all users
+sudo mv macOSMonterey /usr/share/icons/
+```
+
+##### macOSBigSur
 
 ```bash
 # extract `macOSBigSur.tar.gz`
@@ -54,27 +101,21 @@ sudo mv macOSBigSur /usr/share/icons/
 
 #### Windows
 
-1. unzip `macOSBigSur_Windows.zip` file
-2. Open `macOSBigSur_Windows/` in Explorer, and **right click** on `install.inf`.
+##### macOSMonterey
+
+1. unzip `macOSMonterey-Windows.zip` file
+2. Open `macOSMonterey-Windows/` in Explorer, and **right click** on `install.inf`.
+3. Click 'Install' from the context menu, and authorize the modifications to your system.
+4. Open _Control Panel > Personalization and Appearance > Change mouse pointers_, and select **MacOSMonterey Cursors**.
+5. Click '**Apply**'.
+
+##### macOSBigSur
+
+1. unzip `macOSBigSur-Windows.zip` file
+2. Open `macOSBigSur-Windows/` in Explorer, and **right click** on `install.inf`.
 3. Click 'Install' from the context menu, and authorize the modifications to your system.
 4. Open _Control Panel > Personalization and Appearance > Change mouse pointers_, and select **MacOSBigSur Cursors**.
 5. Click '**Apply**'.
-
-#### Preview:
-
-> Check Figma file [here](https://www.figma.com/file/OZw8Ylb9xPFw9h1uZYSMFa/Mac-Cursor?node-id=0%3A1)
-
-<p align="center">
-  <img title="macOSBigSur" src="https://imgur.com/Q022eSp.png">
-  </br>
-  <sub>macOSBigSur Cursors</sub>
-</p>
-
-<p align="center">
-  <img title="macOSBigSur White" src="https://imgur.com/SFVR945.png">
-  </br>
-  <sub>macOSBigSur White Cursors</sub>
-</p>
 
 # Dependencies
 
@@ -132,11 +173,13 @@ sudo dnf install libX11-devel libXcursor-devel libpng-devel
 
 ## Build From Scratch
 
-### ⚡ Auto Build (using GitHub Actions)
+### Auto Build (using GitHub Actions)
 
 GitHub Actions is automatically runs on every `push`(on **main** and **dev** branches) and `pull request`(on **main** branch), You found theme resources in `artifact` section of **build**.GitHub **Actions** source is available inside [.github/workflows](https://github.com/ful1e5/apple_cursor/tree/main/.github/workflows) directory.
 
 ### Manual Build
+
+> Check **[Makefile](./Makefile)** for more targets.
 
 ```bash
 make

--- a/bitmapper/Makefile
+++ b/bitmapper/Makefile
@@ -15,4 +15,7 @@ install: node_modules package.json
 render_bigsur:
 	@yarn render:bigsur
 
-render: render_bigsur
+render_monterey:
+	@yarn render:monterey
+
+render: render_bigsur render_monterey

--- a/bitmapper/package.json
+++ b/bitmapper/package.json
@@ -7,7 +7,8 @@
   "license": "GPL-3.0",
   "private": true,
   "scripts": {
-    "render:bigsur": "yarn workspace bigsur render"
+    "render:bigsur": "yarn workspace bigsur render",
+    "render:monterey": "yarn workspace monterey render"
   },
   "workspaces": [
     "packages/*"

--- a/bitmapper/package.json
+++ b/bitmapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-cursor",
-  "version": "1.1.2",
+  "version": "1.2.2",
   "description": "OpenSource macOS cursors.",
   "main": "index.js",
   "author": "Kaiz Khatri",

--- a/bitmapper/package.json
+++ b/bitmapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-cursor",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "OpenSource macOS cursors.",
   "main": "index.js",
   "author": "Kaiz Khatri",

--- a/bitmapper/packages/bigsur/package.json
+++ b/bitmapper/packages/bigsur/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigsur",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "macOS Big Sur cursors",
   "main": "dist/index.js",
   "scripts": {

--- a/bitmapper/packages/core/package.json
+++ b/bitmapper/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Apple Cursor bitmapper's core modules",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/bitmapper/packages/monterey/package.json
+++ b/bitmapper/packages/monterey/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "monterey",
+  "version": "1.2.2",
+  "description": "macOS Monterey  cursors",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "npx tsc --build",
+    "render": "yarn build && node dist/index.js"
+  },
+  "author": "Kaiz Khatri",
+  "license": "GPL-3.0",
+  "private": true,
+  "devDependencies": {
+    "ts-node": "^9.1.1",
+    "typescript": "^4.1.5"
+  }
+}

--- a/bitmapper/packages/monterey/package.json
+++ b/bitmapper/packages/monterey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monterey",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "macOS Monterey  cursors",
   "main": "dist/index.js",
   "scripts": {

--- a/bitmapper/packages/monterey/src/config.ts
+++ b/bitmapper/packages/monterey/src/config.ts
@@ -1,0 +1,28 @@
+import { Colors } from "core/src/types";
+
+interface Config {
+  themeName: string;
+  color: Colors;
+}
+
+const black = "#000000";
+const white = "#FFFFFF";
+
+const config: Config[] = [
+  {
+    themeName: "macOSMonterey",
+    color: {
+      base: black,
+      outline: white,
+    },
+  },
+  {
+    themeName: "macOSMonterey-White",
+    color: {
+      base: white,
+      outline: black,
+    },
+  },
+];
+
+export { config };

--- a/bitmapper/packages/monterey/src/index.ts
+++ b/bitmapper/packages/monterey/src/index.ts
@@ -1,0 +1,37 @@
+import path from "path";
+
+import { BitmapsGenerator, SVGHandler } from "core";
+import { config } from "./config";
+
+const root = path.resolve(__dirname, "../../../../");
+const svgDir = path.resolve(root, "svg", "monterey");
+
+const main = async () => {
+  for (const { themeName, color } of config) {
+    console.log("=>", themeName);
+
+    const bitmapsDir = path.resolve(root, "bitmaps", themeName);
+    const svg = new SVGHandler.SvgDirectoryParser(svgDir);
+
+    const png = new BitmapsGenerator(bitmapsDir);
+    const browser = await png.getBrowser();
+
+    for (let { key, content } of svg.getStatic()) {
+      console.log(" -> Saving", key, "...");
+
+      content = SVGHandler.colorSvg(content, color);
+      await png.generateStatic(browser, content, key);
+    }
+
+    for (let { key, content } of svg.getAnimated()) {
+      console.log(" -> Saving", key, "...");
+
+      content = SVGHandler.colorSvg(content, color);
+      await png.generateAnimated(browser, content, key);
+    }
+
+    await browser.close();
+  }
+};
+
+main();

--- a/bitmapper/packages/monterey/tsconfig.json
+++ b/bitmapper/packages/monterey/tsconfig.json
@@ -1,0 +1,10 @@
+
+{
+  "references": [{ "path": "../core" }],
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/builder/Makefile
+++ b/builder/Makefile
@@ -15,19 +15,27 @@ THEMES = White
 setup:
 	@python3 -m pip install clickgen --user
 
-build: build_bigsur
+build: build_bigsur build_monterey
 build_bigsur: build.py
 	@python3 build.py -p "$(bitmaps_dir)/macOSBigSur" --xsizes $(X_SIZES) --win-size $(WIN_SIZE) --win-canvas-size $(WIN_CANVAS_SIZE)
 	@$(foreach theme,$(THEMES), python3 build.py -p "$(bitmaps_dir)/macOSBigSur-$(theme)" --xsizes $(X_SIZES) --win-size $(WIN_SIZE) --win-canvas-size $(WIN_CANVAS_SIZE);)
+build_monterey: build.py
+	@python3 build.py -p "$(bitmaps_dir)/macOSMonterey" --xsizes $(X_SIZES) --win-size $(WIN_SIZE) --win-canvas-size $(WIN_CANVAS_SIZE)
+	@$(foreach theme,$(THEMES), python3 build.py -p "$(bitmaps_dir)/macOSMonterey-$(theme)" --xsizes $(X_SIZES) --win-size $(WIN_SIZE) --win-canvas-size $(WIN_CANVAS_SIZE);)
 
-
-build_unix: build_bigsur_unix
+build_unix: build_bigsur_unix build_monterey_unix
 build_bigsur_unix: build.py
 	@python3 build.py unix -p "$(bitmaps_dir)/macOSBigSur" --xsizes $(X_SIZES)
 	@$(foreach theme,$(THEMES), python3 build.py unix -p "$(bitmaps_dir)/macOSBigSur-$(theme)" --xsizes $(X_SIZES);)
+build_monterey_unix: build.py
+	@python3 build.py unix -p "$(bitmaps_dir)/macOSMonterey" --xsizes $(X_SIZES)
+	@$(foreach theme,$(THEMES), python3 build.py unix -p "$(bitmaps_dir)/macOSMonterey-$(theme)" --xsizes $(X_SIZES);)
 
 
-build_windows: build_bigsur_windows
+build_windows: build_bigsur_windows build_monterey_windows
 build_bigsur_windows: build.py
 	@python3 build.py windows -p "$(bitmaps_dir)/macOSBigSur" --win-size $(WIN_SIZE) --win-canvas-size $(WIN_CANVAS_SIZE)
 	@$(foreach theme,$(THEMES), python3 build.py windows -p "$(bitmaps_dir)/macOSBigSur-$(theme)" --win-size $(WIN_SIZE) --win-canvas-size $(WIN_CANVAS_SIZE);)
+build_monterey_windows: build.py
+	@python3 build.py windows -p "$(bitmaps_dir)/macOSMonterey" --win-size $(WIN_SIZE) --win-canvas-size $(WIN_CANVAS_SIZE)
+	@$(foreach theme,$(THEMES), python3 build.py windows -p "$(bitmaps_dir)/macOSMonterey-$(theme)" --win-size $(WIN_SIZE) --win-canvas-size $(WIN_CANVAS_SIZE);)

--- a/pling/bigsur-white.bbcode
+++ b/pling/bigsur-white.bbcode
@@ -5,8 +5,10 @@ Latest build: check [url=https://github.com/ful1e5/apple_cursor/actions]Actions[
 Release Notification: [url=https://twitter.com/ful1e5]@ful1e5[/url]
 Custom Size build docs: [url=https://github.com/ful1e5/apple_cursor#manual-build]README.md#manual-build[/url]
 
-[b]Looking for other macOSBigSur cursor themes?[/b]
+[b]Looking for other macOS cursor themes?[/b]
 [url=https://www.pling.com/p/1408466]macOSBigSur[/url]
+[url=https://www.pling.com/p/1648124]macOSMonterey[/url]
+[url=https://www.pling.com/p/1648129]macOSMonterey White[/url]
 
 [b] Support Creator[/b]
 [url=https://liberapay.com/ful1e5][img]https://liberapay.com/assets/widgets/donate.svg[/img][/url]

--- a/pling/bigsur.bbcode
+++ b/pling/bigsur.bbcode
@@ -5,8 +5,10 @@ Latest build: check [url=https://github.com/ful1e5/apple_cursor/actions]Actions[
 Release Notification: [url=https://twitter.com/ful1e5]@ful1e5[/url]
 Custom Size build docs: [url=https://github.com/ful1e5/apple_cursor#manual-build]README.md#manual-build[/url]
 
-[b]Looking for other macOSBigSur cursor themes?[/b]
+[b]Looking for other macOS cursor themes?[/b]
 [url=https://www.pling.com/p/1616779]macOSBigSur White[/url]
+[url=https://www.pling.com/p/1648124]macOSMonterey[/url]
+[url=https://www.pling.com/p/1648129]macOSMonterey White[/url]
 
 [b] Support Creator[/b]
 [url=https://liberapay.com/ful1e5][img]https://liberapay.com/assets/widgets/donate.svg[/img][/url]

--- a/pling/monterey-white.bbcode
+++ b/pling/monterey-white.bbcode
@@ -1,0 +1,37 @@
+macOSMonterey White cursor theme for Windows and Linux with [b]HiDPI[/b] display support. This cursor theme is built with [b][url=https://github.com/ful1e5/clickgen]clickgen[/url][/b] and render with the [b][url=https://github.com/puppeteer/puppeteer/]puppeteer[/url][/b]. This cursor theme support [b]22, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88, 96[/b] size. Check [url=https://github.com/ful1e5/apple_cursor#manual-build]README.md[/url] for create custom size theme. You also download and test upcoming version from [url=https://github.com/ful1e5/apple_cursor/actions]GitHub Actions[/url] section. Follow me on [url=https://twitter.com/ful1e5]Twitter[/url] for more updates.
+
+Available Sizes: 22, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88, 96
+Latest build: check [url=https://github.com/ful1e5/apple_cursor/actions]Actions[/url][/b] tab on GitHub.
+Release Notification: [url=https://twitter.com/ful1e5]@ful1e5[/url]
+Custom Size build docs: [url=https://github.com/ful1e5/apple_cursor#manual-build]README.md#manual-build[/url]
+
+[b]Looking for other macOS cursor themes?[/b]
+[url=https://www.pling.com/p/1648124]macOSMonterey[/url]
+[url=https://www.pling.com/p/1408466]macOSBigSur[/url]
+[url=https://www.pling.com/p/1616779]macOSBigSur White[/url]
+
+[b] Support Creator[/b]
+[url=https://liberapay.com/ful1e5][img]https://liberapay.com/assets/widgets/donate.svg[/img][/url]
+
+[b]Linux Install[/b]
+Get the latest stable Linux release from the [b]files[/b] section. Unpack the [b].tar.gz[/b] file and follow these [b]commands[/b].
+[code]
+mv macOSMonterey-White ~/.icons                     # install as local
+sudo mv macOSMonterey-White /usr/share/icons        # install as root
+[/code]
+
+[b]Linux Uninstall[/b]
+[code]
+rm -r ~/.icons/macOSMonterey-White                  # remove from local
+sudo rm -r /usr/share/icons/macOSMonterey-White     # remove from root
+[/code]
+
+[b]Window Install[/b]
+[1] unzip [b]macOSMonterey-White-Windows.zip[/b] file.
+[2] Open [b]macOSMonterey-White-Windows/[/b] in Explorer, and [b]right-click[/b] on [b]install.inf[/b].
+[3] Click 'Install' from the context menu, and authorize the modifications to your system.
+[4] Open [i]Control Panel > Personalisation and Appearance > Change mouse pointers[/i], and select [b]macOSMonterey-White Cursors[/b].
+[5] Click '[b]Apply[/b]'.
+
+[b]License & Terms[/b]
+'apple_cursor' is available under the terms of the 'GPL-3.0' license.

--- a/pling/monterey.bbcode
+++ b/pling/monterey.bbcode
@@ -1,0 +1,37 @@
+macOSMonterey cursor theme for Windows and Linux with [b]HiDPI[/b] display support. This cursor theme is built with [b][url=https://github.com/ful1e5/clickgen]clickgen[/url][/b] and render with the [b][url=https://github.com/puppeteer/puppeteer/]puppeteer[/url][/b]. This cursor theme support [b]22, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88, 96[/b] size. Check [url=https://github.com/ful1e5/apple_cursor#manual-build]README.md[/url] for create custom size theme. You also download and test upcoming version from [url=https://github.com/ful1e5/apple_cursor/actions]GitHub Actions[/url] section. Follow me on [url=https://twitter.com/ful1e5]Twitter[/url] for more updates.
+
+Available Sizes: 22, 24, 28, 32, 40, 48, 56, 64, 72, 80, 88, 96
+Latest build: check [url=https://github.com/ful1e5/apple_cursor/actions]Actions[/url][/b] tab on GitHub.
+Release Notification: [url=https://twitter.com/ful1e5]@ful1e5[/url]
+Custom Size build docs: [url=https://github.com/ful1e5/apple_cursor#manual-build]README.md#manual-build[/url]
+
+[b]Looking for other macOS cursor themes?[/b]
+[url=https://www.pling.com/p/1648129]macOSMonterey White[/url]
+[url=https://www.pling.com/p/1408466]macOSBigSur[/url]
+[url=https://www.pling.com/p/1616779]macOSBigSur White[/url]
+
+[b] Support Creator[/b]
+[url=https://liberapay.com/ful1e5][img]https://liberapay.com/assets/widgets/donate.svg[/img][/url]
+
+[b]Linux Install[/b]
+Get the latest stable Linux release from the [b]files[/b] section. Unpack the [b].tar.gz[/b] file and follow these [b]commands[/b].
+[code]
+mv macOSMonterey ~/.icons                     # install as local
+sudo mv macOSMonterey /usr/share/icons        # install as root
+[/code]
+
+[b]Linux Uninstall[/b]
+[code]
+rm -r ~/.icons/macOSMonterey                  # remove from local
+sudo rm -r /usr/share/icons/macOSMonterey     # remove from root
+[/code]
+
+[b]Window Install[/b]
+[1] unzip [b]macOSMonterey-Windows.zip[/b] file.
+[2] Open [b]macOSMonterey-Windows/[/b] in Explorer, and [b]right-click[/b] on [b]install.inf[/b].
+[3] Click 'Install' from the context menu, and authorize the modifications to your system.
+[4] Open [i]Control Panel > Personalisation and Appearance > Change mouse pointers[/i], and select [b]macOSMonterey Cursors[/b].
+[5] Click '[b]Apply[/b]'.
+
+[b]License & Terms[/b]
+'apple_cursor' is available under the terms of the 'GPL-3.0' license.

--- a/svg/bigsur/static/ll_angle.svg
+++ b/svg/bigsur/static/ll_angle.svg
@@ -1,19 +1,19 @@
-<xml version="1.0"?>
+<?xml version="1.0"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" fill="none">
-  <g filter="url(#filter0_d_40)">
+  <g filter="url(#filter0_d_40_458)">
     <path fill-rule="evenodd" clip-rule="evenodd" d="M143.295 73.2714L88.7414 127.843L108.892 148.007L52.9932 147.996V92.0903L73.1546 112.254L127.73 57.7047L143.295 73.2714Z" fill="#0000FF"/>
     <path d="M146.831 76.8063L150.365 73.271L146.831 69.7361L131.266 54.1694L127.731 50.6343L124.196 54.1683L73.1557 105.184L56.5289 88.5549L47.9932 80.0181V92.0903V147.996V152.995L52.9922 152.996L108.891 153.007L120.96 153.009L112.429 144.472L95.8107 127.843L146.831 76.8063Z" stroke="#0000FF" stroke-width="10"/>
   </g>
   <path fill-rule="evenodd" clip-rule="evenodd" d="M143.295 73.2714L88.7414 127.843L108.892 148.007L52.9932 147.996V92.0903L73.1546 112.254L127.73 57.7047L143.295 73.2714Z" fill="#00FF00"/>
   <defs>
-    <filter id="filter0_d_40" x="24.9932" y="35.5638" width="144.442" height="144.448" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <filter id="filter0_d_40_458" x="24.9932" y="35.5638" width="144.442" height="144.448" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
       <feFlood flood-opacity="0" result="BackgroundImageFix"/>
       <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
       <feOffset dx="-3" dy="7"/>
       <feGaussianBlur stdDeviation="7.5"/>
       <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3 0"/>
-      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_40"/>
-      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_40" result="shape"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_40_458"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_40_458" result="shape"/>
     </filter>
   </defs>
 </svg>

--- a/svg/link.py
+++ b/svg/link.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+from glob import glob
+
+ignore_files = ["center_ptr.svg", "context-menu.svg", "left_ptr.svg", "right_ptr.svg"]
+
+
+def link_svg_dir(src_dir, dst_dir) -> None:
+    for src_path in glob(f"{src_dir}/*"):
+        file_name = os.path.basename(src_path)
+        if file_name not in ignore_files:
+            dst = os.path.join(dst_dir, file_name)
+            if os.path.exists(dst):
+                print(f"Removing old symlink of '{file_name}'")
+                os.remove(dst)
+            print(f"Creating symlink of '{file_name}'")
+            os.symlink(
+                os.path.relpath(src_path, f"{dst_dir}/"),
+                dst,
+            )
+        else:
+            print(f"Ignoring file '{file_name}'")
+
+
+link_svg_dir("bigsur/static", "monterey/static")
+link_svg_dir("bigsur/animated", "monterey/animated")

--- a/svg/monterey/animated/left_ptr_watch.svg
+++ b/svg/monterey/animated/left_ptr_watch.svg
@@ -1,0 +1,1 @@
+../../bigsur/animated/left_ptr_watch.svg

--- a/svg/monterey/animated/wait.svg
+++ b/svg/monterey/animated/wait.svg
@@ -1,0 +1,1 @@
+../../bigsur/animated/wait.svg

--- a/svg/monterey/static/X_cursor.svg
+++ b/svg/monterey/static/X_cursor.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/X_cursor.svg

--- a/svg/monterey/static/all-scroll.svg
+++ b/svg/monterey/static/all-scroll.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/all-scroll.svg

--- a/svg/monterey/static/bottom_left_corner.svg
+++ b/svg/monterey/static/bottom_left_corner.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/bottom_left_corner.svg

--- a/svg/monterey/static/bottom_right_corner.svg
+++ b/svg/monterey/static/bottom_right_corner.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/bottom_right_corner.svg

--- a/svg/monterey/static/bottom_tee.svg
+++ b/svg/monterey/static/bottom_tee.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/bottom_tee.svg

--- a/svg/monterey/static/center_ptr.svg
+++ b/svg/monterey/static/center_ptr.svg
@@ -1,0 +1,24 @@
+<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1782_44)">
+<g filter="url(#filter0_d_1782_44)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M49.0005 143.925L98.8216 20.5779L151.987 146.113L99.7378 125.025L96.1853 124.702L49.0005 143.925Z" fill="#0000FF"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M115.578 178.968L83.5004 178.774L84.6152 78.3151L117.36 78.6399L115.578 178.968Z" fill="#0000FF"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M108.554 166.415L91.8101 166.277L92.1466 101L108.871 101.121L108.554 166.415Z" fill="#00FF00"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M99.2443 42.6052L64.5459 129.454L96.2142 116.502L99.9291 116.763L136.512 131.69L99.2443 42.6052Z" fill="#00FF00"/>
+</g>
+<defs>
+<filter id="filter0_d_1782_44" x="31.0005" y="12.5779" width="132.986" height="188.39" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-3" dy="7"/>
+<feGaussianBlur stdDeviation="7.5"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1782_44"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1782_44" result="shape"/>
+</filter>
+<clipPath id="clip0_1782_44">
+<rect width="200" height="200" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/svg/monterey/static/context-menu.svg
+++ b/svg/monterey/static/context-menu.svg
@@ -1,0 +1,26 @@
+<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1782_30)">
+<g filter="url(#filter0_d_1782_30)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M96 154C96 165.046 104.954 174 116 174H173V87H96V154Z" fill="#0000FF"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M105 165.765L74.1137 179L34 83.3901L65.5803 70L105 165.765Z" fill="#0000FF"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M27 160V22L127 122.12H68.4977L64.9519 123.189L27 160Z" fill="#0000FF"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M156.286 122.875H112.714V114.25H156.286V122.875ZM156.286 140.125H112.714V131.5H156.286V140.125ZM156.286 157.375H112.714V148.75H156.286V157.375ZM104 166H165V97H104V166Z" fill="#00FF00"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M93 160.351L77.3349 167L51 103.657L66.6396 97L93 160.351Z" fill="#00FF00"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M35 44V139L60.4538 114.664L64.1231 113.484H105L35 44Z" fill="#00FF00"/>
+</g>
+<defs>
+<filter id="filter0_d_1782_30" x="9" y="14" width="176" height="187" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-3" dy="7"/>
+<feGaussianBlur stdDeviation="7.5"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1782_30"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1782_30" result="shape"/>
+</filter>
+<clipPath id="clip0_1782_30">
+<rect width="200" height="200" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/svg/monterey/static/copy.svg
+++ b/svg/monterey/static/copy.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/copy.svg

--- a/svg/monterey/static/cross.svg
+++ b/svg/monterey/static/cross.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/cross.svg

--- a/svg/monterey/static/crossed_circle.svg
+++ b/svg/monterey/static/crossed_circle.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/crossed_circle.svg

--- a/svg/monterey/static/crosshair.svg
+++ b/svg/monterey/static/crosshair.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/crosshair.svg

--- a/svg/monterey/static/dnd_no_drop.svg
+++ b/svg/monterey/static/dnd_no_drop.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/dnd_no_drop.svg

--- a/svg/monterey/static/dotbox.svg
+++ b/svg/monterey/static/dotbox.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/dotbox.svg

--- a/svg/monterey/static/hand1.svg
+++ b/svg/monterey/static/hand1.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/hand1.svg

--- a/svg/monterey/static/hand2.svg
+++ b/svg/monterey/static/hand2.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/hand2.svg

--- a/svg/monterey/static/left_ptr.svg
+++ b/svg/monterey/static/left_ptr.svg
@@ -1,0 +1,24 @@
+<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1782_16)">
+<g filter="url(#filter0_d_1782_16)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M51 147V7L152 108.571H92.9127L89.3314 109.655L51 147Z" fill="#0000FF"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M129 152.644L97.6787 166L57 69.5129L89.0251 56L129 152.644Z" fill="#0000FF"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M118 146.256L101.589 153L74 88.7524L90.3843 82L118 146.256Z" fill="#00FF00"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M59 28V125L84.8174 100.152L88.5391 98.9466H130L59 28Z" fill="#00FF00"/>
+</g>
+<defs>
+<filter id="filter0_d_1782_16" x="33" y="-1" width="131" height="189" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-3" dy="7"/>
+<feGaussianBlur stdDeviation="7.5"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1782_16"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1782_16" result="shape"/>
+</filter>
+<clipPath id="clip0_1782_16">
+<rect width="200" height="200" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/svg/monterey/static/left_side.svg
+++ b/svg/monterey/static/left_side.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/left_side.svg

--- a/svg/monterey/static/left_tee.svg
+++ b/svg/monterey/static/left_tee.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/left_tee.svg

--- a/svg/monterey/static/link.svg
+++ b/svg/monterey/static/link.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/link.svg

--- a/svg/monterey/static/ll_angle.svg
+++ b/svg/monterey/static/ll_angle.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/ll_angle.svg

--- a/svg/monterey/static/lr_angle.svg
+++ b/svg/monterey/static/lr_angle.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/lr_angle.svg

--- a/svg/monterey/static/move.svg
+++ b/svg/monterey/static/move.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/move.svg

--- a/svg/monterey/static/pencil.svg
+++ b/svg/monterey/static/pencil.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/pencil.svg

--- a/svg/monterey/static/plus.svg
+++ b/svg/monterey/static/plus.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/plus.svg

--- a/svg/monterey/static/question_arrow.svg
+++ b/svg/monterey/static/question_arrow.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/question_arrow.svg

--- a/svg/monterey/static/right_ptr.svg
+++ b/svg/monterey/static/right_ptr.svg
@@ -1,0 +1,24 @@
+<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1782_2)">
+<g filter="url(#filter0_d_1782_2)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M156 160V20L55 121.571H114.087L117.669 122.655L156 160Z" fill="#0000FF"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M77 165.644L108.321 179L149 82.5129L116.975 69L77 165.644Z" fill="#0000FF"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M88 159.256L104.411 166L132 101.752L115.616 95L88 159.256Z" fill="#00FF00"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M147 41V138L121.183 113.152L117.461 111.947H76L147 41Z" fill="#00FF00"/>
+</g>
+<defs>
+<filter id="filter0_d_1782_2" x="37" y="12" width="131" height="189" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-3" dy="7"/>
+<feGaussianBlur stdDeviation="7.5"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1782_2"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1782_2" result="shape"/>
+</filter>
+<clipPath id="clip0_1782_2">
+<rect width="200" height="200" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/svg/monterey/static/right_tee.svg
+++ b/svg/monterey/static/right_tee.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/right_tee.svg

--- a/svg/monterey/static/sb_down_arrow.svg
+++ b/svg/monterey/static/sb_down_arrow.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/sb_down_arrow.svg

--- a/svg/monterey/static/sb_h_double_arrow.svg
+++ b/svg/monterey/static/sb_h_double_arrow.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/sb_h_double_arrow.svg

--- a/svg/monterey/static/sb_left_arrow.svg
+++ b/svg/monterey/static/sb_left_arrow.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/sb_left_arrow.svg

--- a/svg/monterey/static/sb_right_arrow.svg
+++ b/svg/monterey/static/sb_right_arrow.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/sb_right_arrow.svg

--- a/svg/monterey/static/sb_up_arrow.svg
+++ b/svg/monterey/static/sb_up_arrow.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/sb_up_arrow.svg

--- a/svg/monterey/static/sb_v_double_arrow.svg
+++ b/svg/monterey/static/sb_v_double_arrow.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/sb_v_double_arrow.svg

--- a/svg/monterey/static/top_side.svg
+++ b/svg/monterey/static/top_side.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/top_side.svg

--- a/svg/monterey/static/top_tee.svg
+++ b/svg/monterey/static/top_tee.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/top_tee.svg

--- a/svg/monterey/static/ul_angle.svg
+++ b/svg/monterey/static/ul_angle.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/ul_angle.svg

--- a/svg/monterey/static/ur_angle.svg
+++ b/svg/monterey/static/ur_angle.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/ur_angle.svg

--- a/svg/monterey/static/vertical-text.svg
+++ b/svg/monterey/static/vertical-text.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/vertical-text.svg

--- a/svg/monterey/static/wayland-cursor.svg
+++ b/svg/monterey/static/wayland-cursor.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/wayland-cursor.svg

--- a/svg/monterey/static/xterm.svg
+++ b/svg/monterey/static/xterm.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/xterm.svg

--- a/svg/monterey/static/zoom-in.svg
+++ b/svg/monterey/static/zoom-in.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/zoom-in.svg

--- a/svg/monterey/static/zoom-out.svg
+++ b/svg/monterey/static/zoom-out.svg
@@ -1,0 +1,1 @@
+../../bigsur/static/zoom-out.svg


### PR DESCRIPTION
## What kind of change does this PR introduce?

### Added

- macOSMonterey cursors added 🎊  #66 fixed
- Generate master `bitmaps.zip` inside `bin` directory
- `Makefile` binaries targets with variable
- pling docs: size and support info updated
- `bigsur` cursor bitmapper as node package
- New commands added inside `Makefile` for `bitmapper`
- symlink script for `macOSMonterey` svg files

### Changed

- Removed unnecessary badges from `README.md`
- Simplified README.md (removed emojis)
- sponsor with liberapay
- fixed text cursor state in `xterm` & `vertical-text` (increase border size) #67
- bitmapper `core` as node package
- macOSBigSur .svg files moved to `svgs/bigsur` directory


## Checklist

- [x] Documentation
- [x] Testing <!-- We can only merge the PR if this is checked -->
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- Thank you for contributing! -->
